### PR TITLE
Fix docker CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ jobs:
       python: 3.7
     - os: linux
       python: 3.8
-    - os: linux
-      python: 3.9
+    # - os: linux
+    #   python: 3.9
     - os: linux
       python: 3.7
       env:
@@ -32,10 +32,10 @@ jobs:
       python: 3.8
       env:
         - USE_DOCKER: true
-    - os: linux
-      python: 3.9
-      env:
-        - USE_DOCKER: true
+    #  - os: linux
+    #    python: 3.9
+    #    env:
+    #      - USE_DOCKER: true
 
 install:
   - env | sort -u
@@ -60,7 +60,9 @@ script:
         pytest -vvvv -m "docker"  # Run the tests and check for test coverage.
         status=$?
         docker logs $container_id
-        exit $status
+        if [ $status -gt 0 ]; then
+            exit $status
+        fi
     else
         pytest -vvvv -m "not docker"  # Run the tests and check for test coverage.
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,21 +19,21 @@ jobs:
   fast_finish: true
   include:
     - os: linux
-      python: 3.6
-    - os: linux
       python: 3.7
     - os: linux
       python: 3.8
     - os: linux
-      python: 3.6
-      env:
-        - USE_DOCKER: true
+      python: 3.9
     - os: linux
       python: 3.7
       env:
         - USE_DOCKER: true
     - os: linux
       python: 3.8
+      env:
+        - USE_DOCKER: true
+    - os: linux
+      python: 3.9
       env:
         - USE_DOCKER: true
 
@@ -57,10 +57,12 @@ script:
   - |
     if [ ! -z "$USE_DOCKER" ]; then
         container_id=$(docker run -d -t --init --rm --name sirepo -e SIREPO_AUTH_METHODS=bluesky:guest -e SIREPO_AUTH_BLUESKY_SECRET=bluesky -e SIREPO_SRDB_ROOT=/sirepo -e SIREPO_COOKIE_IS_SECURE=false -p 8000:8000 -v $PWD/sirepo_bluesky/tests/SIREPO_SRDB_ROOT:/SIREPO_SRDB_ROOT:ro,z radiasoft/sirepo:beta bash -l -c "mkdir -v -p /sirepo/user/ && cp -Rv /SIREPO_SRDB_ROOT/* /sirepo/user/ && sirepo service http")
-        coverage run -m pytest -vvvv -m "docker"  # Run the tests and check for test coverage.
+        pytest -vvvv -m "docker"  # Run the tests and check for test coverage.
+        status=$?
         docker logs $container_id
+        exit $status
     else
-        coverage run -m pytest -vvvv -m "not docker"  # Run the tests and check for test coverage.
+        pytest -vvvv -m "not docker"  # Run the tests and check for test coverage.
     fi
   - coverage report -m  # Generate test coverage report.
   - codecov  # Upload the report to codecov.

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,4 @@ script:
     else
         pytest -vvvv -m "not docker"  # Run the tests and check for test coverage.
     fi
-  - coverage report -m  # Generate test coverage report.
-  - codecov  # Upload the report to codecov.
   - make -C docs html  # Build the documentation.


### PR DESCRIPTION
Updates to the PR https://github.com/NSLS-II/sirepo-bluesky/pull/20 branch:
- remove Python 3.6 tests (fails with older `intake` v0.6.1, which does not have required features of v0.6.2)
- add placeholders for Python 3.9 in the future
- remove `coverage` due to recent cyber issues with that
- make sure the failed docker tests cause the TravisCI jobs to have the failed status